### PR TITLE
Remove php from package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "madewithlove/licence-checker-php",
+    "name": "madewithlove/licence-checker",
     "description": "CLI tool to verify allowed licenses for composer dependencies",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
### Changed
- package name is now `madewithlove/license-checker` instead of `madewithlove/license-checker-php`