### PR TITLE
Allow older version of symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "symfony/console": "^4.0 || ^5.0",
         "symfony/process": "^4.0 || ^5.0",
-        "symfony/yaml": "4.0 || ^5.0"
+        "symfony/yaml": "^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.0"

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "symfony/console": "^5.0",
-        "symfony/process": "^5.0",
-        "symfony/yaml": "^5.0"
+        "symfony/console": "^4.0 || ^5.0",
+        "symfony/process": "^4.0 || ^5.0",
+        "symfony/yaml": "4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.0"


### PR DESCRIPTION
### Changed
- We are now compatible with older symfony components (4.x)

---
Fixes https://github.com/madewithlove/license-checker-php/issues/7