### PR TITLE
Allow spaces in license names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ To configure a list of allowed licenses, simply create an `.allowed-licences` fi
 The file could look like this:
 ```
 # contents of .allowed-licenses
-MIT
-BSD-3-Clause
+- MIT
+- BSD-3-Clause
+- New BSD License
 ```
 
 ## Usage

--- a/src/Configuration/.allowed-licenses
+++ b/src/Configuration/.allowed-licenses
@@ -1,3 +1,4 @@
 MIT
 BSD-3-Clause
 Apache-2
+New BSD License

--- a/src/Configuration/.allowed-licenses
+++ b/src/Configuration/.allowed-licenses
@@ -1,4 +1,4 @@
-MIT
-BSD-3-Clause
-Apache-2
-New BSD License
+- MIT
+- BSD-3-Clause
+- Apache-2
+- New BSD License

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -14,7 +14,6 @@ class AllowedLicensesParser
      */
     public function getAllowedLicenses(string $pathToConfigurationFile): array
     {
-        $value = Yaml::parseFile($pathToConfigurationFile . '/' . self::CONFIG_FILE_NAME);
-        return explode(' ', $value);
+        return Yaml::parseFile($pathToConfigurationFile . '/' . self::CONFIG_FILE_NAME);
     }
 }

--- a/src/Configuration/AllowedLicensesParserTest.php
+++ b/src/Configuration/AllowedLicensesParserTest.php
@@ -17,6 +17,7 @@ class AllowedLicensesParserTest extends TestCase
             'MIT',
             'BSD-3-Clause',
             'Apache-2',
+            'New BSD License',
         ];
 
         $this->assertEquals($expected, $allowedLicenses);


### PR DESCRIPTION
### Changed
- [BREAKING] Configuration should now be defined as a Yaml array:
```
- New BSD License
- MIT
```

### Fixed
- Issue with parsing license names containing spaces