### PR TITLE
Add vendor binary definition for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "minimum-stability": "stable",
+    "bin": ["bin/licensed"],
     "require": {
         "symfony/console": "^4.0 || ^5.0",
         "symfony/process": "^4.0 || ^5.0",


### PR DESCRIPTION
### Added
- Vendor binary definition for composer. This will make it easier to run the library from a global install.