### PR TITLE
Sort and clean lists of licenses

### DIFF
--- a/src/Composer/LicenseParser.php
+++ b/src/Composer/LicenseParser.php
@@ -18,6 +18,8 @@ class LicenseParser
             }
         }
 
+        sort($licenses);
+
         return array_unique($licenses);
     }
 

--- a/src/Composer/LicenseParser.php
+++ b/src/Composer/LicenseParser.php
@@ -20,7 +20,7 @@ class LicenseParser
 
         sort($licenses);
 
-        return array_unique($licenses);
+        return array_values(array_unique($licenses));
     }
 
     /**

--- a/src/Composer/LicenseParser.php
+++ b/src/Composer/LicenseParser.php
@@ -13,7 +13,9 @@ class LicenseParser
         $licenses = [];
         $decodedJson = json_decode($json, true);
         foreach ($decodedJson['dependencies'] as $dependency) {
-            $licenses[] = $dependency['license'][0];
+            if (isset($dependency['license'][0])) {
+                $licenses[] = $dependency['license'][0];
+            }
         }
 
         return array_unique($licenses);

--- a/src/Composer/LicenseParserTest.php
+++ b/src/Composer/LicenseParserTest.php
@@ -62,9 +62,9 @@ class LicenseParserTest extends TestCase
     }
 }';
         $expected = [
-            'FOO',
             'BAR',
             'BAZ',
+            'FOO',
         ];
 
         $this->assertEquals(

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -14,6 +14,9 @@ class AllowedLicensesParser
      */
     public function getAllowedLicenses(string $pathToConfigurationFile): array
     {
-        return Yaml::parseFile($pathToConfigurationFile . '/' . self::CONFIG_FILE_NAME);
+        $allowedLicenses = Yaml::parseFile($pathToConfigurationFile . '/' . self::CONFIG_FILE_NAME);
+        sort($allowedLicenses);
+
+        return $allowedLicenses;
     }
 }

--- a/src/Configuration/AllowedLicensesParserTest.php
+++ b/src/Configuration/AllowedLicensesParserTest.php
@@ -14,9 +14,9 @@ class AllowedLicensesParserTest extends TestCase
         $parser = new AllowedLicensesParser();
         $allowedLicenses = $parser->getAllowedLicenses(__DIR__ );
         $expected = [
-            'MIT',
-            'BSD-3-Clause',
             'Apache-2',
+            'BSD-3-Clause',
+            'MIT',
             'New BSD License',
         ];
 


### PR DESCRIPTION
### Changed
- Lists of used and allowed licenses are now sorted alphabetically

### Fixed
- Packages without a license no longer give a warning during parsing