### PR TITLE
Cache the output of the retrieved data

### DIFF
--- a/src/Composer/DependencyTreeRetriever.php
+++ b/src/Composer/DependencyTreeRetriever.php
@@ -7,8 +7,14 @@ use Symfony\Component\Process\Process;
 
 class DependencyTreeRetriever
 {
+    private static $output;
+
     public function getDependencyTree(): string
     {
+        if (!is_null(self::$output)) {
+            return self::$output;
+        }
+
         $process = new Process(['composer', 'show', '-t', '-f', 'json']);
         $process->run();
 
@@ -16,6 +22,8 @@ class DependencyTreeRetriever
             throw new ProcessFailedException($process);
         }
 
-        return $process->getOutput();
+        self::$output = $process->getOutput();
+
+        return self::$output;
     }
 }

--- a/src/Composer/UsedLicensesRetriever.php
+++ b/src/Composer/UsedLicensesRetriever.php
@@ -7,8 +7,14 @@ use Symfony\Component\Process\Process;
 
 class UsedLicensesRetriever
 {
+    private static $output;
+
     public function getComposerLicenses(): string
     {
+        if (!is_null(self::$output)) {
+            return self::$output;
+        }
+
         $process = new Process(['composer', 'license', '-f', 'json']);
         $process->run();
 
@@ -16,6 +22,8 @@ class UsedLicensesRetriever
             throw new ProcessFailedException($process);
         }
 
-        return $process->getOutput();
+        self::$output = $process->getOutput();
+
+        return self::$output;
     }
 }


### PR DESCRIPTION
This makes sure we can call these retrieves in loops without huge
performance changes.

We can safely assume that the composer data won't change during a run, so just using the first data is pretty safe.