### PR TITLE
Bump minimum version to PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,20 @@ jobs:
         name: Psalm
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout code
-              uses: actions/checkout@master
-            - name: Psalm
-              uses: docker://vimeo/psalm-github-actions
+            - uses: actions/checkout@master
+            - uses: shivammathur/setup-php@master
+              with:
+                  php-version: '8.0'
+            - name: Install dependencies
+              run: composer update
+            - name: Run Psalm
+              run: vendor/bin/psalm
 
     phpunit:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
-            - uses: shivammathur/setup-php@v1
+            - uses: shivammathur/setup-php@master
               with:
                   php-version: '8.0'
             - name: Install dependencies
@@ -27,7 +31,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@master
-            -   uses: shivammathur/setup-php@v1
+            -   uses: shivammathur/setup-php@master
                 with:
                     php-version: '8.0'
             -   name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
               with:
                   php-version: '8.0'
             - name: Install dependencies
-              run: composer install -n --prefer-dist
+              run: composer update
             - name: Run PHPUnit unit tests
               run: vendor/bin/phpunit
 
@@ -31,6 +31,6 @@ jobs:
                 with:
                     php-version: '8.0'
             -   name: Install dependencies
-                run: composer install -n --prefer-dist
+                run: composer update
             -   name: Run License Checker
                 run: bin/license-checker check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,11 @@ jobs:
 
     phpunit:
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                php-versions: ['7.2', '7.3', '7.4']
         steps:
             - uses: actions/checkout@master
             - uses: shivammathur/setup-php@v1
               with:
-                  php-version: ${{ matrix.php-versions }}
+                  php-version: '8.0'
             - name: Install dependencies
               run: composer install -n --prefer-dist
             - name: Run PHPUnit unit tests
@@ -32,7 +29,7 @@ jobs:
             -   uses: actions/checkout@master
             -   uses: shivammathur/setup-php@v1
                 with:
-                    php-version: '7.4'
+                    php-version: '8.0'
             -   name: Install dependencies
                 run: composer install -n --prefer-dist
             -   name: Run License Checker

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 /vendor/
 composer.lock
+.phpunit.result.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:cli-alpine
+FROM php:8-cli-alpine
 
 ENV COMPOSER_HOME /composer
 ENV COMPOSER_ALLOW_SUPERUSER 1

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ pipeline to block merging when a non-verified license is being introduced to the
 
 ## Installation
 Installing should be a breeze thanks to `composer`:
+Note that you need PHP 8 to install the latest version (1.x). 
+If you are using an older version of PHP (7.x), older versions can be installed (0.x).
 
 ```
 composer require madewithlove/license-checker

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "vimeo/psalm": "^3.9"
+        "vimeo/psalm": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,13 @@
     "minimum-stability": "stable",
     "bin": ["bin/license-checker"],
     "require": {
+        "php": "^8.0",
         "symfony/console": "^4.0 || ^5.0",
         "symfony/process": "^4.0 || ^5.0",
         "symfony/yaml": "^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5 || ^9.0",
+        "phpunit/phpunit": "^9.5",
         "vimeo/psalm": "^3.9"
     },
     "autoload": {

--- a/src/Commands/CheckLicenses.php
+++ b/src/Commands/CheckLicenses.php
@@ -18,37 +18,13 @@ class CheckLicenses extends Command
 {
     protected static $defaultName = 'check';
 
-    /**
-     * @var UsedLicensesParser
-     */
-    private $usedLicenseParser;
-
-    /**
-     * @var AllowedLicensesParser
-     */
-    private $allowedLicensesParser;
-
-    /**
-     * @var DependencyTree
-     */
-    private $dependencyTree;
-
-    /**
-     * @var TableRenderer
-     */
-    private $tableRenderer;
-
     public function __construct(
-        UsedLicensesParser $usedLicensesParser,
-        AllowedLicensesParser $allowedLicensesParser,
-        DependencyTree $dependencyTree,
-        TableRenderer $tableRenderer
+        private UsedLicensesParser $usedLicensesParser,
+        private AllowedLicensesParser $allowedLicensesParser,
+        private DependencyTree $dependencyTree,
+        private TableRenderer $tableRenderer
     ) {
         parent::__construct();
-        $this->usedLicenseParser = $usedLicensesParser;
-        $this->allowedLicensesParser = $allowedLicensesParser;
-        $this->dependencyTree = $dependencyTree;
-        $this->tableRenderer = $tableRenderer;
     }
 
     protected function configure(): void
@@ -56,12 +32,12 @@ class CheckLicenses extends Command
         $this->setDescription('Check licenses of composer dependencies');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 
         try {
-            $usedLicenses = $this->usedLicenseParser->parseLicenses();
+            $usedLicenses = $this->usedLicensesParser->parseLicenses();
         } catch (ProcessFailedException $e) {
             $output->writeln($e->getMessage());
             return 1;
@@ -81,7 +57,7 @@ class CheckLicenses extends Command
         foreach ($dependencies as $dependency) {
             $dependencyCheck = new DependencyCheck($dependency->getName());
             foreach ($notAllowedLicenses as $notAllowedLicense) {
-                $packagesUsingThisLicense = $this->usedLicenseParser->getPackagesWithLicense($notAllowedLicense);
+                $packagesUsingThisLicense = $this->usedLicensesParser->getPackagesWithLicense($notAllowedLicense);
                 foreach ($packagesUsingThisLicense as $packageUsingThisLicense) {
                     if ($dependency->hasDependency($packageUsingThisLicense) || $dependency->getName() === $packageUsingThisLicense) {
                         $dependencyCheck = $dependencyCheck->addFailedDependency($packageUsingThisLicense, $notAllowedLicense);

--- a/src/Commands/CountUsedLicenses.php
+++ b/src/Commands/CountUsedLicenses.php
@@ -3,7 +3,6 @@
 namespace LicenseChecker\Commands;
 
 use LicenseChecker\Composer\UsedLicensesParser;
-use LicenseChecker\Composer\UsedLicensesRetriever;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -14,16 +13,10 @@ class CountUsedLicenses extends Command
 {
     protected static $defaultName = 'count';
 
-    /**
-     * @var UsedLicensesParser
-     */
-    private $usedLicensesParser;
-
     public function __construct(
-        UsedLicensesParser $usedLicensesParser
+        private UsedLicensesParser $usedLicensesParser
     ) {
         parent::__construct();
-        $this->usedLicensesParser = $usedLicensesParser;
     }
 
     protected function configure(): void
@@ -31,7 +24,7 @@ class CountUsedLicenses extends Command
         $this->setDescription('Count number of dependencies for each license');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $rows = [];

--- a/src/Commands/GenerateConfig.php
+++ b/src/Commands/GenerateConfig.php
@@ -15,23 +15,11 @@ class GenerateConfig extends Command
 {
     protected static $defaultName = 'generate-config';
 
-    /**
-     * @var AllowedLicensesParser
-     */
-    private $allowedLicensesParser;
-
-    /**
-     * @var UsedLicensesParser
-     */
-    private $usedLicensesParser;
-
     public function __construct(
-        AllowedLicensesParser $allowedLicensesParser,
-        UsedLicensesParser $usedLicensesParser
+        private AllowedLicensesParser $allowedLicensesParser,
+        private UsedLicensesParser $usedLicensesParser
     ) {
         parent::__construct();
-        $this->allowedLicensesParser = $allowedLicensesParser;
-        $this->usedLicensesParser = $usedLicensesParser;
     }
 
     protected function configure(): void
@@ -39,7 +27,7 @@ class GenerateConfig extends Command
         $this->setDescription('Generates allowed licenses config based on used licenses');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Commands/ListAllowedLicenses.php
+++ b/src/Commands/ListAllowedLicenses.php
@@ -12,24 +12,18 @@ class ListAllowedLicenses extends Command
 {
     protected static $defaultName = 'allowed';
 
-    /**
-     * @var AllowedLicensesParser
-     */
-    private $allowedLicensesParser;
-
-    public function __construct(AllowedLicensesParser $allowedLicensesParser)
-    {
+    public function __construct(
+        private AllowedLicensesParser $allowedLicensesParser
+    ) {
         parent::__construct();
-        $this->allowedLicensesParser = $allowedLicensesParser;
     }
-
 
     protected function configure(): void
     {
         $this->setDescription('List used licenses of composer dependencies');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses(getcwd());

--- a/src/Commands/ListUsedLicenses.php
+++ b/src/Commands/ListUsedLicenses.php
@@ -13,16 +13,10 @@ class ListUsedLicenses extends Command
 {
     protected static $defaultName = 'used';
 
-    /**
-     * @var UsedLicensesParser
-     */
-    private $usedLicensesParser;
-
     public function __construct(
-        UsedLicensesParser $usedLicensesParser
+        private UsedLicensesParser $usedLicensesParser
     ) {
         parent::__construct();
-        $this->usedLicensesParser = $usedLicensesParser;
     }
 
     protected function configure(): void
@@ -30,7 +24,7 @@ class ListUsedLicenses extends Command
         $this->setDescription('List used licenses of composer dependencies');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $usedLicenses = $this->usedLicensesParser->parseLicenses();

--- a/src/Commands/Output/CauseOfFailure.php
+++ b/src/Commands/Output/CauseOfFailure.php
@@ -4,21 +4,10 @@ namespace LicenseChecker\Commands\Output;
 
 final class CauseOfFailure
 {
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var string
-     */
-    private $license;
-
-    public function __construct(string $name, string $license)
-    {
-        $this->name = $name;
-        $this->license = $license;
-    }
+    public function __construct(
+        private string $name,
+        private string $license
+    ) {}
 
     public function getName(): string
     {

--- a/src/Commands/Output/DependencyCheck.php
+++ b/src/Commands/Output/DependencyCheck.php
@@ -4,30 +4,18 @@ namespace LicenseChecker\Commands\Output;
 
 final class DependencyCheck
 {
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
-     * @var bool
-     */
-    private $isAllowed = true;
+    private bool $isAllowed = true;
 
     /**
      * @var CauseOfFailure[]
      */
-    private $causedBy = [];
+    private array $causedBy = [];
 
-    /**
-     * @param string $name
-     */
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    public function __construct(
+        private string $name
+    ) {}
 
-    public function addFailedDependency($dependency, $license): self
+    public function addFailedDependency(string $dependency, string $license): self
     {
         $dependencyCheck = clone $this;
         $dependencyCheck->isAllowed = false;

--- a/src/Commands/Output/TableRenderer.php
+++ b/src/Commands/Output/TableRenderer.php
@@ -8,11 +8,10 @@ class TableRenderer
 {
     /**
      * @param DependencyCheck[] $dependencyChecks
-     * @param SymfonyStyle $io
      */
-    public function renderDependencyChecks(array $dependencyChecks, SymfonyStyle $io)
+    public function renderDependencyChecks(array $dependencyChecks, SymfonyStyle $io): void
     {
-        usort($dependencyChecks, function (DependencyCheck $dependencyCheck, DependencyCheck $other) {
+        usort($dependencyChecks, function (DependencyCheck $dependencyCheck, DependencyCheck $other): int {
             return $dependencyCheck->isAllowed() <=> $other->isAllowed();
         });
 
@@ -24,7 +23,6 @@ class TableRenderer
 
     /**
      * @param DependencyCheck[] $dependencyChecks
-     * @return bool
      */
     private function hasFailures(array $dependencyChecks): bool
     {
@@ -103,7 +101,6 @@ class TableRenderer
     }
 
     /**
-     * @param DependencyCheck $dependencyCheck
      * @return string[]
      */
     private function renderAllowedLineWithEmptyFailureCause(DependencyCheck $dependencyCheck): array
@@ -116,8 +113,6 @@ class TableRenderer
     }
 
     /**
-     * @param DependencyCheck $dependencyCheck
-     * @param CauseOfFailure $causeOfFailure
      * @return string[]
      */
     private function renderFailedLineWithCauseOfFailure(
@@ -132,7 +127,6 @@ class TableRenderer
     }
 
     /**
-     * @param CauseOfFailure $causeOfFailure
      * @return string[]
      */
     private function renderAdditionalCauseOfFailure(CauseOfFailure $causeOfFailure): array

--- a/src/Commands/Output/TableRendererTest.php
+++ b/src/Commands/Output/TableRendererTest.php
@@ -8,15 +8,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class TableRendererTest extends TestCase
 {
-    /**
-     * @var SymfonyStyle | MockObject
-     */
-    private $io;
-
-    /**
-     * @var TableRenderer
-     */
-    private $tableRenderer;
+    private SymfonyStyle|MockObject $io;
+    private TableRenderer $tableRenderer;
 
     protected function setUp(): void
     {
@@ -27,7 +20,7 @@ class TableRendererTest extends TestCase
     /**
      * @test
      */
-    public function itWillRenderTwoColumnsOnSuccess()
+    public function itWillRenderTwoColumnsOnSuccess(): void
     {
         $this->io->expects($this->once())->method('table')->with(
             ['','dependency'],
@@ -51,7 +44,7 @@ class TableRendererTest extends TestCase
     /**
      * @test
      */
-    public function itWillListCausingPackagesOnFailure()
+    public function itWillListCausingPackagesOnFailure(): void
     {
         $this->io->expects($this->once())->method('table')->with(
             ['', 'dependency', 'caused by'],
@@ -76,7 +69,7 @@ class TableRendererTest extends TestCase
     /**
      * @test
      */
-    public function itWillRenderFailingDependenciesFirst()
+    public function itWillRenderFailingDependenciesFirst(): void
     {
         $this->io->expects($this->once())->method('table')->with(
             ['', 'dependency', 'caused by'],

--- a/src/Composer/DependencyTree.php
+++ b/src/Composer/DependencyTree.php
@@ -6,15 +6,9 @@ use LicenseChecker\Dependency;
 
 class DependencyTree
 {
-    /**
-     * @var DependencyTreeRetriever
-     */
-    private $retriever;
-
-    public function __construct(DependencyTreeRetriever $dependencyTreeRetriever)
-    {
-        $this->retriever = $dependencyTreeRetriever;
-    }
+    public function __construct(
+        private DependencyTreeRetriever $retriever)
+    {}
 
     /**
      * @return Dependency[]
@@ -37,7 +31,6 @@ class DependencyTree
     }
 
     /**
-     * @param array $subTree
      * @return string[]
      */
     private function getSubDependencies(array $subTree): array

--- a/src/Composer/DependencyTreeRetriever.php
+++ b/src/Composer/DependencyTreeRetriever.php
@@ -7,11 +7,11 @@ use Symfony\Component\Process\Process;
 
 class DependencyTreeRetriever
 {
-    private static $output;
+    private static string $output = '';
 
     public function getDependencyTree(): string
     {
-        if (!is_null(self::$output)) {
+        if (!empty(self::$output)) {
             return self::$output;
         }
 

--- a/src/Composer/DependencyTreeTest.php
+++ b/src/Composer/DependencyTreeTest.php
@@ -8,15 +8,8 @@ use PHPUnit\Framework\TestCase;
 
 class DependencyTreeTest extends TestCase
 {
-    /**
-     * @var DependencyTreeRetriever | MockObject
-     */
-    private $retriever;
-
-    /**
-     * @var DependencyTree
-     */
-    private $dependencyTree;
+    private DependencyTreeRetriever|MockObject $retriever;
+    private DependencyTree $dependencyTree;
 
     protected function setUp(): void
     {

--- a/src/Composer/UsedLicenseParserTest.php
+++ b/src/Composer/UsedLicenseParserTest.php
@@ -7,15 +7,8 @@ use PHPUnit\Framework\TestCase;
 
 class UsedLicenseParserTest extends TestCase
 {
-    /**
-     * @var UsedLicensesParser
-     */
-    private $usedLicensesParser;
-
-    /**
-     * @var UsedLicensesRetriever | MockObject
-     */
-    private $licenseRetriever;
+    private UsedLicensesParser $usedLicensesParser;
+    private UsedLicensesRetriever|MockObject $licenseRetriever;
 
     protected function setUp(): void
     {

--- a/src/Composer/UsedLicensesParser.php
+++ b/src/Composer/UsedLicensesParser.php
@@ -4,15 +4,9 @@ namespace LicenseChecker\Composer;
 
 class UsedLicensesParser
 {
-    /**
-     * @var UsedLicensesRetriever
-     */
-    private $retriever;
-
-    public function __construct(UsedLicensesRetriever $retriever)
-    {
-        $this->retriever = $retriever;
-    }
+    public function __construct(
+        private UsedLicensesRetriever $retriever
+    ) {}
 
     /**
      * @return string[]
@@ -33,7 +27,6 @@ class UsedLicensesParser
     }
 
     /**
-     * @param string $license
      * @return string[]
      */
     public function getPackagesWithLicense(string $license): array

--- a/src/Composer/UsedLicensesRetriever.php
+++ b/src/Composer/UsedLicensesRetriever.php
@@ -7,11 +7,11 @@ use Symfony\Component\Process\Process;
 
 class UsedLicensesRetriever
 {
-    private static $output;
+    private static string $output = '';
 
     public function getComposerLicenses(): string
     {
-        if (!is_null(self::$output)) {
+        if (!empty(self::$output)) {
             return self::$output;
         }
 

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -9,7 +9,6 @@ class AllowedLicensesParser
     private const CONFIG_FILE_NAME = '.allowed-licenses';
 
     /**
-     * @param string $pathToConfigurationFile
      * @return string[]
      */
     public function getAllowedLicenses(string $pathToConfigurationFile): array
@@ -23,7 +22,7 @@ class AllowedLicensesParser
     /**
      * @param string[] $allowedLicenses
      */
-    public function writeConfiguration(array $allowedLicenses)
+    public function writeConfiguration(array $allowedLicenses): void
     {
         if ($this->configurationExists(getcwd())) {
             throw new ConfigurationExists();

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -5,19 +5,13 @@ namespace LicenseChecker;
 class Dependency
 {
     /**
-     * @var string
-     */
-    private $name;
-
-    /**
      * @var string[]
      */
-    private $subDependencies = [];
+    private array $subDependencies = [];
 
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    public function __construct(
+        private string $name
+    ) {}
 
     public function addDependency(string $dependency): self
     {


### PR DESCRIPTION
### Changed
- [BREAKING] minimum PHP version is now 8. We will bump with a major version.
- Cleaned up all types and properties
- CI pipeline now exclusively runs PHP 8