### PR TITLE
Custom config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The file could look like this:
 - New BSD License
 ```
 
+It's possible to use a custom configuration file by passing the `--filename` (or `-f`) option to the CLI commands.
+
 ## Usage
 These are the different CLI commands
 
@@ -44,4 +46,12 @@ vendor/bin/license-checker check
 This command will automatically generate an `.allowed-licenses` configuration based on the currently used licenses.
 ```
 vendor/bin/license-checker generate-config
+```
+
+### Excluding development dependencies
+Passing the `--no-dev` option to the CLI commands will scope all checks to production dependencies only.
+Checking production and development dependencies against separate configuration files is possible by passing options:
+```
+vendor/bin/license-checker check --no-dev --filename .allowed-licenses-production
+vendor/bin/license-checker check --filename .allowed-licenses-including-dev
 ```

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -32,9 +32,11 @@ if (!$autoLoader) {
 
 $application = new Application('License Checker', '0.0.1');
 
+$allowedLicensesParser = new AllowedLicensesParser(getcwd());
+
 $checkLicenses = new CheckLicenses(
     new UsedLicensesParser(new UsedLicensesRetriever()),
-    new AllowedLicensesParser(),
+    $allowedLicensesParser,
     new DependencyTree(new DependencyTreeRetriever()),
     new TableRenderer()
 );
@@ -45,13 +47,11 @@ $listUsedLicenses = new ListUsedLicenses(
 );
 $application->add($listUsedLicenses);
 
-$listAllowedLicenses = new ListAllowedLicenses(
-    new AllowedLicensesParser()
-);
+$listAllowedLicenses = new ListAllowedLicenses($allowedLicensesParser);
 $application->add($listAllowedLicenses);
 
 $generateConfig = new GenerateConfig(
-    new AllowedLicensesParser(),
+    $allowedLicensesParser,
     new UsedLicensesParser(new UsedLicensesRetriever())
 );
 $application->add($generateConfig);

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -41,18 +41,11 @@ $checkLicenses = new CheckLicenses(
     new DependencyTree(new DependencyTreeRetriever()),
     new TableRenderer()
 );
+
 $application->add($checkLicenses);
-
-$listUsedLicenses = new ListUsedLicenses($usedLicensesParser);
-$application->add($listUsedLicenses);
-
-$listAllowedLicenses = new ListAllowedLicenses($allowedLicensesParser);
-$application->add($listAllowedLicenses);
-
-$generateConfig = new GenerateConfig($allowedLicensesParser, $usedLicensesParser);
-$application->add($generateConfig);
-
-$countUsedLicenses = new CountUsedLicenses($usedLicensesParser);
-$application->add($countUsedLicenses);
+$application->add(new ListUsedLicenses($usedLicensesParser));
+$application->add(new ListAllowedLicenses($allowedLicensesParser));
+$application->add(new GenerateConfig($allowedLicensesParser, $usedLicensesParser));
+$application->add(new CountUsedLicenses($usedLicensesParser));
 
 $application->run();

--- a/bin/license-checker
+++ b/bin/license-checker
@@ -33,32 +33,26 @@ if (!$autoLoader) {
 $application = new Application('License Checker', '0.0.1');
 
 $allowedLicensesParser = new AllowedLicensesParser(getcwd());
+$usedLicensesParser = new UsedLicensesParser(new UsedLicensesRetriever());
 
 $checkLicenses = new CheckLicenses(
-    new UsedLicensesParser(new UsedLicensesRetriever()),
+    $usedLicensesParser,
     $allowedLicensesParser,
     new DependencyTree(new DependencyTreeRetriever()),
     new TableRenderer()
 );
 $application->add($checkLicenses);
 
-$listUsedLicenses = new ListUsedLicenses(
-    new UsedLicensesParser(new UsedLicensesRetriever())
-);
+$listUsedLicenses = new ListUsedLicenses($usedLicensesParser);
 $application->add($listUsedLicenses);
 
 $listAllowedLicenses = new ListAllowedLicenses($allowedLicensesParser);
 $application->add($listAllowedLicenses);
 
-$generateConfig = new GenerateConfig(
-    $allowedLicensesParser,
-    new UsedLicensesParser(new UsedLicensesRetriever())
-);
+$generateConfig = new GenerateConfig($allowedLicensesParser, $usedLicensesParser);
 $application->add($generateConfig);
 
-$countUsedLicenses = new CountUsedLicenses(
-    new UsedLicensesParser(new UsedLicensesRetriever())
-);
+$countUsedLicenses = new CountUsedLicenses($usedLicensesParser);
 $application->add($countUsedLicenses);
 
 $application->run();

--- a/src/Commands/CheckLicenses.php
+++ b/src/Commands/CheckLicenses.php
@@ -32,8 +32,14 @@ class CheckLicenses extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Check licenses of composer dependencies')
-            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Do not include dev dependencies');
+        $this->setDescription('Check licenses of composer dependencies');
+        $this->addOption('no-dev', null, InputOption::VALUE_NONE, 'Do not include dev dependencies');
+        $this->addOption(
+            'filename',
+            'f',
+            InputOption::VALUE_OPTIONAL,
+            'Optional filename to be used instead of the default'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -48,7 +54,9 @@ class CheckLicenses extends Command
         }
 
         try {
-            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses();
+            /** @var string|null $fileName */
+            $fileName = is_string($input->getOption('filename')) ? $input->getOption('filename') : null;
+            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses($fileName);
         } catch (ParseException $e) {
             $output->writeln($e->getMessage());
             return 1;

--- a/src/Commands/CheckLicenses.php
+++ b/src/Commands/CheckLicenses.php
@@ -48,7 +48,7 @@ class CheckLicenses extends Command
         }
 
         try {
-            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses(getcwd());
+            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses();
         } catch (ParseException $e) {
             $output->writeln($e->getMessage());
             return 1;

--- a/src/Commands/GenerateConfig.php
+++ b/src/Commands/GenerateConfig.php
@@ -27,8 +27,14 @@ class GenerateConfig extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Generates allowed licenses config based on used licenses')
-            ->addOption('no-dev', null, InputOption::VALUE_NONE, 'Do not include dev dependencies');
+        $this->setDescription('Generates allowed licenses config based on used licenses');
+        $this->addOption('no-dev', null, InputOption::VALUE_NONE, 'Do not include dev dependencies');
+        $this->addOption(
+            'filename',
+            'f',
+            InputOption::VALUE_OPTIONAL,
+            'Optional filename to be used instead of the default'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,7 +51,9 @@ class GenerateConfig extends Command
         sort($usedLicenses);
 
         try {
-            $this->allowedLicensesParser->writeConfiguration(array_values($usedLicenses));
+            /** @var string|null $fileName */
+            $fileName = is_string($input->getOption('filename')) ? $input->getOption('filename') : null;
+            $this->allowedLicensesParser->writeConfiguration(array_values($usedLicenses), $fileName);
             $io->success('Configuration file successfully written');
         } catch (ConfigurationExists $e) {
             $io->error('The configuration file already exists. Please remove it before generating a new one.');

--- a/src/Commands/ListAllowedLicenses.php
+++ b/src/Commands/ListAllowedLicenses.php
@@ -28,7 +28,7 @@ class ListAllowedLicenses extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses(getcwd());
+            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses();
         } catch (ParseException $e) {
             $output->writeln($e->getMessage());
             return 1;

--- a/src/Commands/ListAllowedLicenses.php
+++ b/src/Commands/ListAllowedLicenses.php
@@ -7,6 +7,7 @@ namespace LicenseChecker\Commands;
 use LicenseChecker\Configuration\AllowedLicensesParser;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Exception\ParseException;
 
@@ -23,12 +24,20 @@ class ListAllowedLicenses extends Command
     protected function configure(): void
     {
         $this->setDescription('List used licenses of composer dependencies');
+        $this->addOption(
+            'filename',
+            'f',
+            InputOption::VALUE_OPTIONAL,
+            'Optional filename to be used instead of the default'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses();
+            /** @var string|null $fileName */
+            $fileName = is_string($input->getOption('filename')) ? $input->getOption('filename') : null;
+            $allowedLicenses = $this->allowedLicensesParser->getAllowedLicenses($fileName);
         } catch (ParseException $e) {
             $output->writeln($e->getMessage());
             return 1;

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -19,10 +19,10 @@ class AllowedLicensesParser
      * @return list<string>
      */
     public function getAllowedLicenses(
-        string $fileName = self::DEFAULT_CONFIG_FILE_NAME
+        ?string $fileName
     ): array {
         /** @var list<string> $allowedLicenses */
-        $allowedLicenses = Yaml::parseFile($this->getConfigurationFilePath($fileName));
+        $allowedLicenses = Yaml::parseFile($this->getConfigurationFilePath($fileName ?? self::DEFAULT_CONFIG_FILE_NAME));
         sort($allowedLicenses);
 
         return $allowedLicenses;

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -8,7 +8,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class AllowedLicensesParser
 {
-    private const CONFIG_FILE_NAME = '.allowed-licenses';
+    private const DEFAULT_CONFIG_FILE_NAME = '.allowed-licenses';
 
     /**
      * @return list<string>
@@ -16,7 +16,7 @@ class AllowedLicensesParser
     public function getAllowedLicenses(string $pathToConfigurationFile): array
     {
         /** @var list<string> $allowedLicenses */
-        $allowedLicenses = Yaml::parseFile($pathToConfigurationFile . '/' . self::CONFIG_FILE_NAME);
+        $allowedLicenses = Yaml::parseFile($pathToConfigurationFile . '/' . self::DEFAULT_CONFIG_FILE_NAME);
         sort($allowedLicenses);
 
         return $allowedLicenses;
@@ -45,6 +45,6 @@ class AllowedLicensesParser
             $path = getcwd();
         }
 
-        return $path . '/' . self::CONFIG_FILE_NAME;
+        return $path . '/' . self::DEFAULT_CONFIG_FILE_NAME;
     }
 }

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -10,6 +10,11 @@ class AllowedLicensesParser
 {
     private const DEFAULT_CONFIG_FILE_NAME = '.allowed-licenses';
 
+    public function __construct(
+        private string $workingDirectory
+    ) {
+    }
+
     /**
      * @return list<string>
      */
@@ -18,7 +23,7 @@ class AllowedLicensesParser
         string $fileName = self::DEFAULT_CONFIG_FILE_NAME
     ): array {
         /** @var list<string> $allowedLicenses */
-        $allowedLicenses = Yaml::parseFile($pathToConfigurationFile . '/' . $fileName);
+        $allowedLicenses = Yaml::parseFile($this->getConfigurationFilePath($fileName));
         sort($allowedLicenses);
 
         return $allowedLicenses;
@@ -41,8 +46,8 @@ class AllowedLicensesParser
         return file_exists($this->getConfigurationFilePath());
     }
 
-    private function getConfigurationFilePath(): string
+    private function getConfigurationFilePath(string $fileName = self::DEFAULT_CONFIG_FILE_NAME): string
     {
-        return getcwd() . '/' . self::DEFAULT_CONFIG_FILE_NAME;
+        return $this->workingDirectory . '/' . $fileName;
     }
 }

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -19,7 +19,6 @@ class AllowedLicensesParser
      * @return list<string>
      */
     public function getAllowedLicenses(
-        string $pathToConfigurationFile,
         string $fileName = self::DEFAULT_CONFIG_FILE_NAME
     ): array {
         /** @var list<string> $allowedLicenses */

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -31,8 +31,9 @@ class AllowedLicensesParser
     /**
      * @param string[] $allowedLicenses
      */
-    public function writeConfiguration(array $allowedLicenses, string $fileName = self::DEFAULT_CONFIG_FILE_NAME): void
+    public function writeConfiguration(array $allowedLicenses, ?string $fileName): void
     {
+        $fileName = $fileName ?? self::DEFAULT_CONFIG_FILE_NAME;
         if ($this->configurationExists($fileName)) {
             throw new ConfigurationExists();
         }

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -29,24 +29,20 @@ class AllowedLicensesParser
      */
     public function writeConfiguration(array $allowedLicenses): void
     {
-        if ($this->configurationExists(getcwd())) {
+        if ($this->configurationExists()) {
             throw new ConfigurationExists();
         }
         $yaml = Yaml::dump($allowedLicenses);
         file_put_contents($this->getConfigurationFilePath(), $yaml);
     }
 
-    private function configurationExists(string $pathToConfigurationFile): bool
+    private function configurationExists(): bool
     {
-        return file_exists($this->getConfigurationFilePath($pathToConfigurationFile));
+        return file_exists($this->getConfigurationFilePath());
     }
 
-    private function getConfigurationFilePath(?string $path = null): string
+    private function getConfigurationFilePath(): string
     {
-        if (!$path) {
-            $path = getcwd();
-        }
-
-        return $path . '/' . self::DEFAULT_CONFIG_FILE_NAME;
+        return getcwd() . '/' . self::DEFAULT_CONFIG_FILE_NAME;
     }
 }

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -13,10 +13,12 @@ class AllowedLicensesParser
     /**
      * @return list<string>
      */
-    public function getAllowedLicenses(string $pathToConfigurationFile): array
-    {
+    public function getAllowedLicenses(
+        string $pathToConfigurationFile,
+        string $fileName = self::DEFAULT_CONFIG_FILE_NAME
+    ): array {
         /** @var list<string> $allowedLicenses */
-        $allowedLicenses = Yaml::parseFile($pathToConfigurationFile . '/' . self::DEFAULT_CONFIG_FILE_NAME);
+        $allowedLicenses = Yaml::parseFile($pathToConfigurationFile . '/' . $fileName);
         sort($allowedLicenses);
 
         return $allowedLicenses;

--- a/src/Configuration/AllowedLicensesParser.php
+++ b/src/Configuration/AllowedLicensesParser.php
@@ -31,21 +31,21 @@ class AllowedLicensesParser
     /**
      * @param string[] $allowedLicenses
      */
-    public function writeConfiguration(array $allowedLicenses): void
+    public function writeConfiguration(array $allowedLicenses, string $fileName = self::DEFAULT_CONFIG_FILE_NAME): void
     {
-        if ($this->configurationExists()) {
+        if ($this->configurationExists($fileName)) {
             throw new ConfigurationExists();
         }
         $yaml = Yaml::dump($allowedLicenses);
-        file_put_contents($this->getConfigurationFilePath(), $yaml);
+        file_put_contents($this->getConfigurationFilePath($fileName), $yaml);
     }
 
-    private function configurationExists(): bool
+    private function configurationExists(string $fileName): bool
     {
-        return file_exists($this->getConfigurationFilePath());
+        return file_exists($this->getConfigurationFilePath($fileName));
     }
 
-    private function getConfigurationFilePath(string $fileName = self::DEFAULT_CONFIG_FILE_NAME): string
+    private function getConfigurationFilePath(string $fileName): string
     {
         return $this->workingDirectory . '/' . $fileName;
     }

--- a/tests/Configuration/AllowedLicensesParserTest.php
+++ b/tests/Configuration/AllowedLicensesParserTest.php
@@ -14,7 +14,7 @@ class AllowedLicensesParserTest extends TestCase
      */
     public function canParseConfiguration(): void
     {
-        $parser = new AllowedLicensesParser();
+        $parser = new AllowedLicensesParser(__DIR__.'/data');
         $allowedLicenses = $parser->getAllowedLicenses(__DIR__.'/data');
         $expected = [
             'Apache-2',

--- a/tests/Configuration/AllowedLicensesParserTest.php
+++ b/tests/Configuration/AllowedLicensesParserTest.php
@@ -15,7 +15,7 @@ class AllowedLicensesParserTest extends TestCase
     public function canParseConfiguration(): void
     {
         $parser = new AllowedLicensesParser(__DIR__.'/data');
-        $allowedLicenses = $parser->getAllowedLicenses(__DIR__.'/data');
+        $allowedLicenses = $parser->getAllowedLicenses();
         $expected = [
             'Apache-2',
             'BSD-3-Clause',

--- a/tests/Configuration/AllowedLicensesParserTest.php
+++ b/tests/Configuration/AllowedLicensesParserTest.php
@@ -15,7 +15,7 @@ class AllowedLicensesParserTest extends TestCase
     public function canParseConfiguration(): void
     {
         $parser = new AllowedLicensesParser(__DIR__.'/data');
-        $allowedLicenses = $parser->getAllowedLicenses();
+        $allowedLicenses = $parser->getAllowedLicenses('.allowed-licenses');
         $expected = [
             'Apache-2',
             'BSD-3-Clause',


### PR DESCRIPTION
### Changed
- It's now possible to pass a custom configuration file to the CLI commands. Combining this with the `--no-dev` option solves https://github.com/madewithlove/license-checker-php/issues/25 in a backwards-compatible way. 