### PR TITLE
Run tests with prefer-lowest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,16 @@ jobs:
 
     phpunit:
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                prefer-lowest: [ '', '--prefer-lowest' ]
         steps:
             - uses: actions/checkout@master
             - uses: shivammathur/setup-php@master
               with:
                   php-version: '8.0'
             - name: Install dependencies
-              run: composer update
+              run: composer update -n --prefer-dist  ${{ matrix.prefer-lowest }}
             - name: Run PHPUnit unit tests
               run: vendor/bin/phpunit
 


### PR DESCRIPTION
### Changed
- CI pipeline now also runs test with `--prefer-lowest` dependencies to ensure compatibility