### PR TITLE
Allow use of Symfony 6.x packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,5 +32,10 @@
         "psr-4": {
             "LicenseChecker\\Tests\\": "tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     "bin": ["bin/license-checker"],
     "require": {
         "php": "^8.0",
-        "symfony/console": "^4.0 || ^5.0",
-        "symfony/process": "^4.0 || ^5.0",
-        "symfony/yaml": "^4.0 || ^5.0"
+        "symfony/console": "^4.0 || ^5.0 || ^6.0",
+        "symfony/process": "^4.0 || ^5.0 || ^6.0",
+        "symfony/yaml": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
This PR adds `^6.0` to the list of versions for symfony/console, symfony/process, and symfony/yaml, allowing others who use the license checker to install or upgrade newer versions of these packages.

Thanks!